### PR TITLE
tweak the styling and wording of the front-page tables

### DIFF
--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -22,9 +22,9 @@
   </p>
   <p><strong>{% trans %}Documentation sections:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>
-    <td width="50%">
+    <td width="50%" style="vertical-align: top">
       <p class="biglink"><a class="biglink" href="{{ pathto("whatsnew/" + version) }}">{% trans %}What's new in Python {{ version }}?{% endtrans %}</a><br>
-         <span class="linkdescr"> {% trans whatsnew_index=pathto("whatsnew/index") %}Or <a href="{{ whatsnew_index }}">all "What's new" documents since Python 2.0</a>{% endtrans %}</span></p>
+         <span class="linkdescr"> {% trans whatsnew_index=pathto("whatsnew/index") %}<a href="{{ whatsnew_index }}">All "What's new" documents since Python 2.0</a>{% endtrans %}</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("tutorial/index") }}">{% trans %}Tutorial{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Start here: a tour of Python's syntax and features{% endtrans %}</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("library/index") }}">{% trans %}Library reference{% endtrans %}</a><br>
@@ -35,7 +35,7 @@
          <span class="linkdescr">{% trans %}How to install, configure, and use Python{% endtrans %}</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("howto/index") }}">{% trans %}Python HOWTOs{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}In-depth topic manuals{% endtrans %}</span></p>
-    </td><td width="50%">
+    </td><td width="50%" style="vertical-align: top">
       <p class="biglink"><a class="biglink" href="{{ pathto("installing/index") }}">{% trans %}Installing Python modules{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Third-party modules and PyPI.org{% endtrans %}</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("extending/index") }}">{% trans %}Extending and embedding{% endtrans %}</a><br>
@@ -51,11 +51,11 @@
 
   <p><strong>{% trans %}Other resources:{% endtrans %}</strong></p>
    <table class="contentstable" align="center"><tr>
-      <td width="50%">
+      <td width="50%" style="vertical-align: top">
          <p class="biglink"><a class="biglink" href="https://packaging.python.org">{% trans %}Python Packaging User Guide{% endtrans %}</a><br>
-            <span class="linkdescr">{% trans %}A collection of resources relating to Python packaging{% endtrans %}</span></p>
+            <span class="linkdescr">{% trans %}Resources relating to Python packaging{% endtrans %}</span></p>
       </td>
-      <td width="50%">
+      <td width="50%" style="vertical-align: top">
          <p class="biglink"><a class="biglink" href="https://typing.python.org">{% trans %}Static Typing with Python{% endtrans %}</a><br>
             <span class="linkdescr">{% trans %}Information and guides about Python type safety{% endtrans %}</span></p>
       </td></tr>
@@ -63,28 +63,28 @@
 
   <p><strong>{% trans %}Indices, glossary, and search:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>
-    <td width="50%">
+    <td width="50%" style="vertical-align: top">
       <p class="biglink"><a class="biglink" href="{{ pathto("py-modindex") }}">{% trans %}Global module index{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}All modules and libraries{% endtrans %}</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{% trans %}General index{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}All functions, classes, and terms{% endtrans %}</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("glossary") }}">{% trans %}Glossary{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Terms explained{% endtrans %}</span></p>
-    </td><td width="50%">
+    </td><td width="50%" style="vertical-align: top">
       <p class="biglink"><a class="biglink" href="{{ pathto("search") }}">{% trans %}Search page{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Search this documentation{% endtrans %}</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Complete table of contents{% endtrans %}</a><br>
-         <span class="linkdescr">{% trans %}Lists all sections and subsections{% endtrans %}</span></p>
+         <span class="linkdescr">{% trans %}All sections and subsections{% endtrans %}</span></p>
     </td></tr>
   </table>
 
   <p><strong>{% trans %}Project information:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>
-    <td width="50%">
+    <td width="50%" style="vertical-align: top">
       <p class="biglink"><a class="biglink" href="{{ pathto("bugs") }}">{% trans %}Reporting issues{% endtrans %}</a></p>
       <p class="biglink"><a class="biglink" href="https://devguide.python.org/documentation/help-documenting/">{% trans %}Contributing to docs{% endtrans %}</a></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("download") }}">{% trans %}Download the documentation{% endtrans %}</a></p>
-    </td><td width="50%">
+    </td><td width="50%" style="vertical-align: top">
       <p class="biglink"><a class="biglink" href="{{ pathto("license") }}">{% trans %}History and license of Python{% endtrans %}</a></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("copyright") }}">{% trans %}Copyright{% endtrans %}</a></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("about") }}">{% trans %}About the documentation{% endtrans %}</a></p>


### PR DESCRIPTION
Add CSS to top-align the columns, and adjust the subtitle wording for consistency and length.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--2.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->